### PR TITLE
[OAS] Add delete and update data view entrypoints

### DIFF
--- a/docs/api/data-views/create.asciidoc
+++ b/docs/api/data-views/create.asciidoc
@@ -6,6 +6,11 @@
 
 experimental[] Create data views.
 
+[NOTE]
+====
+For the most up-to-date API details, refer to the
+{kib-repo}/tree/{branch}/src/plugins/data_views/docs/openapi[open API specification].
+====
 
 [[data-views-api-create-request]]
 ==== Request

--- a/docs/api/data-views/delete.asciidoc
+++ b/docs/api/data-views/delete.asciidoc
@@ -8,6 +8,11 @@ experimental[] Delete data views.
 
 WARNING: Once you delete a data view, _it cannot be recovered_.
 
+[NOTE]
+====
+For the most up-to-date API details, refer to the
+{kib-repo}/tree/{branch}/src/plugins/data_views/docs/openapi[open API specification].
+====
 
 [[data-views-api-delete-request]]
 ==== Request

--- a/docs/api/data-views/update.asciidoc
+++ b/docs/api/data-views/update.asciidoc
@@ -7,6 +7,11 @@
 experimental[] Update part of an data view. Only the specified fields are updated in the
 data view. Unspecified fields stay as they are persisted.
 
+[NOTE]
+====
+For the most up-to-date API details, refer to the
+{kib-repo}/tree/{branch}/src/plugins/data_views/docs/openapi[open API specification].
+====
 
 [[data-views-api-update-request]]
 ==== Request

--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -93,6 +93,68 @@
         }
       ]
     },
+    "/api/data_views/data_view": {
+      "post": {
+        "summary": "Creates a data view.",
+        "operationId": "createDataView",
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/create_data_view_request_object"
+              },
+              "examples": {
+                "createDataViewRequest": {
+                  "$ref": "#/components/examples/create_data_view_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/data_view_response_object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/400_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
     "/api/data_views/data_view/{viewId}": {
       "get": {
         "summary": "Retrieves a single data view by identifier.",
@@ -112,56 +174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view": {
-                      "type": "object",
-                      "properties": {
-                        "allowNoIndex": {
-                          "type": "boolean"
-                        },
-                        "fieldAttrs": {
-                          "type": "object"
-                        },
-                        "fieldFormats": {
-                          "type": "object"
-                        },
-                        "fields": {
-                          "type": "object"
-                        },
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "namespaces": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "runtimeFieldMap": {
-                          "type": "object"
-                        },
-                        "sourceFilters": {
-                          "type": "array"
-                        },
-                        "timeFieldName": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "typeMeta": {
-                          "type": "object"
-                        },
-                        "version": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/data_view_response_object"
                 },
                 "examples": {
                   "getDataViewResponse": {
@@ -236,53 +249,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "data_view"
-                ],
-                "properties": {
-                  "data_view": {
-                    "type": "object",
-                    "description": "The data view fields you want to update. Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.\n",
-                    "properties": {
-                      "allowNoIndex": {
-                        "type": "boolean"
-                      },
-                      "fieldFormats": {
-                        "type": "object"
-                      },
-                      "fields": {
-                        "type": "object"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "runtimeFieldMap": {
-                        "type": "object"
-                      },
-                      "sourceFilters": {
-                        "type": "array"
-                      },
-                      "timeFieldName": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "typeMeta": {
-                        "type": "object"
-                      }
-                    }
-                  },
-                  "refresh_fields": {
-                    "type": "boolean",
-                    "description": "Reloads the data view fields after the data view is updated.",
-                    "default": false
-                  }
-                }
+                "$ref": "#/components/schemas/update_data_view_request_object"
               },
               "examples": {
                 "updateDataViewRequest": {
@@ -298,12 +265,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view": {
-                      "type": "object"
-                    }
-                  }
+                  "$ref": "#/components/schemas/data_view_response_object"
                 }
               }
             }
@@ -511,7 +473,7 @@
     },
     "examples": {
       "get_data_views_response": {
-        "summary": "Retrieve the list of data views for Kibana sample data.",
+        "summary": "The get all data views API returns a list of data views.",
         "value": {
           "data_view": [
             {
@@ -542,8 +504,25 @@
           ]
         }
       },
+      "create_data_view_request": {
+        "summary": "Create a data view with runtime fields.",
+        "value": {
+          "data_view": {
+            "title": "logstash-*",
+            "name": "My Logstash data view",
+            "runtimeFieldMap": {
+              "runtime_shape_name": {
+                "type": "keyword",
+                "script": {
+                  "source": "emit(doc['shape_name'].value)"
+                }
+              }
+            }
+          }
+        }
+      },
       "get_data_view_response": {
-        "summary": "Retrieve information about a specific data view.",
+        "summary": "The get data view API returns a JSON object that contains information about the data view.",
         "value": {
           "data_view": {
             "id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f",
@@ -1712,7 +1691,7 @@
         }
       },
       "get_runtime_field_response": {
-        "summary": "Retrieve a runtime field named `hour_of_day` from the data view `d3d7af60-4c81-11e8-b3d7-01146121b73d`.",
+        "summary": "The get runtime field API returns a JSON object that contains information about the runtime field (`hour_of_day`) and the data view (`d3d7af60-4c81-11e8-b3d7-01146121b73d`).",
         "value": {
           "fields": [
             {
@@ -2330,7 +2309,7 @@
         }
       },
       "get_default_data_view_response": {
-        "summary": "Retrieve the default data view identifier.",
+        "summary": "The get default data view API returns the default data view identifier.",
         "value": {
           "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
         }
@@ -2344,6 +2323,15 @@
       }
     },
     "parameters": {
+      "kbn_xsrf": {
+        "schema": {
+          "type": "string"
+        },
+        "in": "header",
+        "name": "kbn-xsrf",
+        "description": "Cross-site request forgery protection",
+        "required": true
+      },
       "view_id": {
         "in": "path",
         "name": "viewId",
@@ -2353,15 +2341,6 @@
           "type": "string",
           "example": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
         }
-      },
-      "kbn_xsrf": {
-        "schema": {
-          "type": "string"
-        },
-        "in": "header",
-        "name": "kbn-xsrf",
-        "description": "Cross-site request forgery protection",
-        "required": true
       },
       "field_name": {
         "in": "path",
@@ -2375,6 +2354,191 @@
       }
     },
     "schemas": {
+      "allownoindex": {
+        "type": "boolean",
+        "description": "Allows the data view saved object to exist before the data is available."
+      },
+      "fieldattrs": {
+        "type": "object",
+        "description": "A map of field attributes by field name."
+      },
+      "fieldformats": {
+        "type": "object",
+        "description": "A map of field formats by field name."
+      },
+      "namespaces": {
+        "type": "array",
+        "description": "An array of space identifiers for sharing the data view between multiple spaces.",
+        "items": {
+          "type": "string",
+          "default": "default"
+        }
+      },
+      "runtimefieldmap": {
+        "type": "object",
+        "description": "A map of runtime field definitions by field name."
+      },
+      "sourcefilters": {
+        "type": "array",
+        "description": "The array of field names you want to filter out in Discover."
+      },
+      "timefieldname": {
+        "type": "string",
+        "description": "The timestamp field name, which you use for time-based data views."
+      },
+      "title": {
+        "type": "string",
+        "description": "Comma-separated list of data streams, indices, and aliases that you want to search. Supports wildcards (`*`)."
+      },
+      "type": {
+        "type": "string",
+        "description": "When set to `rollup`, identifies the rollup data views."
+      },
+      "typemeta": {
+        "type": "object",
+        "description": "When you use rollup indices, contains the field list for the rollup data view API endpoints."
+      },
+      "create_data_view_request_object": {
+        "title": "Create data view request",
+        "type": "object",
+        "required": [
+          "data_view"
+        ],
+        "properties": {
+          "data_view": {
+            "type": "object",
+            "required": [
+              "title"
+            ],
+            "description": "The data view object.",
+            "properties": {
+              "allowNoIndex": {
+                "$ref": "#/components/schemas/allownoindex"
+              },
+              "fieldAttrs": {
+                "$ref": "#/components/schemas/fieldattrs"
+              },
+              "fieldFormats": {
+                "$ref": "#/components/schemas/fieldformats"
+              },
+              "fields": {
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string",
+                "description": "The data view name."
+              },
+              "namespaces": {
+                "$ref": "#/components/schemas/namespaces"
+              },
+              "runtimeFieldMap": {
+                "$ref": "#/components/schemas/runtimefieldmap"
+              },
+              "sourceFilters": {
+                "$ref": "#/components/schemas/sourcefilters"
+              },
+              "timeFieldName": {
+                "$ref": "#/components/schemas/timefieldname"
+              },
+              "title": {
+                "$ref": "#/components/schemas/title"
+              },
+              "type": {
+                "$ref": "#/components/schemas/type"
+              },
+              "typeMeta": {
+                "$ref": "#/components/schemas/typemeta"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "override": {
+            "type": "boolean",
+            "description": "Override an existing data view if a data view with the provided title already exists.",
+            "default": false
+          }
+        }
+      },
+      "data_view_response_object": {
+        "title": "Data view response properties",
+        "type": "object",
+        "properties": {
+          "data_view": {
+            "type": "object",
+            "properties": {
+              "allowNoIndex": {
+                "$ref": "#/components/schemas/allownoindex"
+              },
+              "fieldAttrs": {
+                "$ref": "#/components/schemas/fieldattrs"
+              },
+              "fieldFormats": {
+                "$ref": "#/components/schemas/fieldformats"
+              },
+              "fields": {
+                "type": "object"
+              },
+              "id": {
+                "type": "string",
+                "example": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
+              },
+              "name": {
+                "type": "string",
+                "description": "The data view name."
+              },
+              "namespaces": {
+                "$ref": "#/components/schemas/namespaces"
+              },
+              "runtimeFieldMap": {
+                "$ref": "#/components/schemas/runtimefieldmap"
+              },
+              "sourceFilters": {
+                "$ref": "#/components/schemas/sourcefilters"
+              },
+              "timeFieldName": {
+                "$ref": "#/components/schemas/timefieldname"
+              },
+              "title": {
+                "$ref": "#/components/schemas/title"
+              },
+              "typeMeta": {
+                "$ref": "#/components/schemas/typemeta"
+              },
+              "version": {
+                "type": "string",
+                "example": "WzQ2LDJd"
+              }
+            }
+          }
+        }
+      },
+      "400_response": {
+        "title": "Bad request",
+        "type": "object",
+        "required": [
+          "statusCode",
+          "error",
+          "message"
+        ],
+        "properties": {
+          "statusCode": {
+            "type": "number",
+            "example": 400
+          },
+          "error": {
+            "type": "string",
+            "example": "Bad Request"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
       "404_response": {
         "type": "object",
         "properties": {
@@ -2398,25 +2562,53 @@
           }
         }
       },
-      "400_response": {
-        "title": "Bad request",
+      "update_data_view_request_object": {
+        "title": "Update data view request",
         "type": "object",
         "required": [
-          "statusCode",
-          "error",
-          "message"
+          "data_view"
         ],
         "properties": {
-          "statusCode": {
-            "type": "number",
-            "example": 400
+          "data_view": {
+            "type": "object",
+            "description": "The data view properties you want to update. Only the specified properties are updated in the data view. Unspecified fields stay as they are persisted.\n",
+            "properties": {
+              "allowNoIndex": {
+                "$ref": "#/components/schemas/allownoindex"
+              },
+              "fieldFormats": {
+                "$ref": "#/components/schemas/fieldformats"
+              },
+              "fields": {
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "runtimeFieldMap": {
+                "$ref": "#/components/schemas/runtimefieldmap"
+              },
+              "sourceFilters": {
+                "$ref": "#/components/schemas/sourcefilters"
+              },
+              "timeFieldName": {
+                "$ref": "#/components/schemas/timefieldname"
+              },
+              "title": {
+                "$ref": "#/components/schemas/title"
+              },
+              "type": {
+                "$ref": "#/components/schemas/type"
+              },
+              "typeMeta": {
+                "$ref": "#/components/schemas/typemeta"
+              }
+            }
           },
-          "error": {
-            "type": "string",
-            "example": "Bad Request"
-          },
-          "message": {
-            "type": "string"
+          "refresh_fields": {
+            "type": "boolean",
+            "description": "Reloads the data view fields after the data view is updated.",
+            "default": false
           }
         }
       }

--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -183,6 +183,39 @@
           }
         }
       },
+      "delete": {
+        "summary": "Deletes a data view.",
+        "operationId": "deleteDataView",
+        "description": "WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/view_id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Indicates a successful call."
+          },
+          "404": {
+            "description": "Object is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/404_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
       "post": {
         "summary": "Updates a data view.",
         "operationId": "updateDataView",

--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -183,6 +183,115 @@
           }
         }
       },
+      "post": {
+        "summary": "Updates a data view.",
+        "operationId": "updateDataView",
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/view_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data_view"
+                ],
+                "properties": {
+                  "data_view": {
+                    "type": "object",
+                    "description": "The data view fields you want to update. Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.\n",
+                    "properties": {
+                      "allowNoIndex": {
+                        "type": "boolean"
+                      },
+                      "fieldFormats": {
+                        "type": "object"
+                      },
+                      "fields": {
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "runtimeFieldMap": {
+                        "type": "object"
+                      },
+                      "sourceFilters": {
+                        "type": "array"
+                      },
+                      "timeFieldName": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "typeMeta": {
+                        "type": "object"
+                      }
+                    }
+                  },
+                  "refresh_fields": {
+                    "type": "boolean",
+                    "description": "Reloads the data view fields after the data view is updated.",
+                    "default": false
+                  }
+                }
+              },
+              "examples": {
+                "updateDataViewRequest": {
+                  "$ref": "#/components/examples/update_data_view_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data_view": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/400_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
       "servers": [
         {
           "url": "https://localhost:5601"
@@ -1557,6 +1666,18 @@
           }
         }
       },
+      "update_data_view_request": {
+        "summary": "Update some properties for a data view.",
+        "value": {
+          "data_view": {
+            "title": "kibana_sample_data_ecommerce",
+            "timeFieldName": "order_date",
+            "allowNoIndex": false,
+            "name": "Kibana Sample Data eCommerce"
+          },
+          "refresh_fields": true
+        }
+      },
       "get_runtime_field_response": {
         "summary": "Retrieve a runtime field named `hour_of_day` from the data view `d3d7af60-4c81-11e8-b3d7-01146121b73d`.",
         "value": {
@@ -2200,6 +2321,15 @@
           "example": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
         }
       },
+      "kbn_xsrf": {
+        "schema": {
+          "type": "string"
+        },
+        "in": "header",
+        "name": "kbn-xsrf",
+        "description": "Cross-site request forgery protection",
+        "required": true
+      },
       "field_name": {
         "in": "path",
         "name": "fieldName",
@@ -2209,15 +2339,6 @@
           "type": "string",
           "example": "hour_of_day"
         }
-      },
-      "kbn_xsrf": {
-        "schema": {
-          "type": "string"
-        },
-        "in": "header",
-        "name": "kbn-xsrf",
-        "description": "Cross-site request forgery protection",
-        "required": true
       }
     },
     "schemas": {
@@ -2241,6 +2362,28 @@
             "enum": [
               404
             ]
+          }
+        }
+      },
+      "400_response": {
+        "title": "Bad request",
+        "type": "object",
+        "required": [
+          "statusCode",
+          "error",
+          "message"
+        ],
+        "properties": {
+          "statusCode": {
+            "type": "number",
+            "example": 400
+          },
+          "error": {
+            "type": "string",
+            "example": "Bad Request"
+          },
+          "message": {
+            "type": "string"
           }
         }
       }

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -114,6 +114,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+    delete:
+      summary: Deletes a data view.
+      operationId: deleteDataView
+      description: |
+        WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/view_id'
+      responses:
+        '204':
+          description: Indicates a successful call.
+        '404':
+          description: Object is not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404_response'
+      servers:
+        - url: https://localhost:5601
     post:
       summary: Updates a data view.
       operationId: updateDataView

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -56,6 +56,42 @@ paths:
                   $ref: '#/components/examples/get_data_views_response'
     servers:
       - url: https://localhost:5601
+  /api/data_views/data_view:
+    post:
+      summary: Creates a data view.
+      operationId: createDataView
+      description: |
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/create_data_view_request_object'
+            examples:
+              createDataViewRequest:
+                $ref: '#/components/examples/create_data_view_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/data_view_response_object'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}:
     get:
       summary: Retrieves a single data view by identifier.
@@ -72,39 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
-                    properties:
-                      allowNoIndex:
-                        type: boolean
-                      fieldAttrs:
-                        type: object
-                      fieldFormats:
-                        type: object
-                      fields:
-                        type: object
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      namespaces:
-                        type: array
-                        items:
-                          type: string
-                      runtimeFieldMap:
-                        type: object
-                      sourceFilters:
-                        type: array
-                      timeFieldName:
-                        type: string
-                      title:
-                        type: string
-                      typeMeta:
-                        type: object
-                      version:
-                        type: string
+                $ref: '#/components/schemas/data_view_response_object'
               examples:
                 getDataViewResponse:
                   $ref: '#/components/examples/get_data_view_response'
@@ -149,39 +153,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - data_view
-              properties:
-                data_view:
-                  type: object
-                  description: |
-                    The data view fields you want to update. Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.
-                  properties:
-                    allowNoIndex:
-                      type: boolean
-                    fieldFormats:
-                      type: object
-                    fields:
-                      type: object
-                    name:
-                      type: string
-                    runtimeFieldMap:
-                      type: object
-                    sourceFilters:
-                      type: array
-                    timeFieldName:
-                      type: string
-                    title:
-                      type: string
-                    type:
-                      type: string
-                    typeMeta:
-                      type: object
-                refresh_fields:
-                  type: boolean
-                  description: Reloads the data view fields after the data view is updated.
-                  default: false
+              $ref: '#/components/schemas/update_data_view_request_object'
             examples:
               updateDataViewRequest:
                 $ref: '#/components/examples/update_data_view_request'
@@ -191,10 +163,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
+                $ref: '#/components/schemas/data_view_response_object'
         '400':
           description: Bad request
           content:
@@ -318,7 +287,7 @@ components:
       name: ApiKey
   examples:
     get_data_views_response:
-      summary: Retrieve the list of data views for Kibana sample data.
+      summary: The get all data views API returns a list of data views.
       value:
         data_view:
           - id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
@@ -337,8 +306,19 @@ components:
               - default
             title: kibana_sample_data_logs
             name: Kibana Sample Data Logs
+    create_data_view_request:
+      summary: Create a data view with runtime fields.
+      value:
+        data_view:
+          title: logstash-*
+          name: My Logstash data view
+          runtimeFieldMap:
+            runtime_shape_name:
+              type: keyword
+              script:
+                source: emit(doc['shape_name'].value)
     get_data_view_response:
-      summary: Retrieve information about a specific data view.
+      summary: The get data view API returns a JSON object that contains information about the data view.
       value:
         data_view:
           id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
@@ -1274,7 +1254,7 @@ components:
           name: Kibana Sample Data eCommerce
         refresh_fields: true
     get_runtime_field_response:
-      summary: Retrieve a runtime field named `hour_of_day` from the data view `d3d7af60-4c81-11e8-b3d7-01146121b73d`.
+      summary: The get runtime field API returns a JSON object that contains information about the runtime field (`hour_of_day`) and the data view (`d3d7af60-4c81-11e8-b3d7-01146121b73d`).
       value:
         fields:
           - count: 0
@@ -1773,7 +1753,7 @@ components:
           allowNoIndex: false
           name: Kibana Sample Data Flights
     get_default_data_view_response:
-      summary: Retrieve the default data view identifier.
+      summary: The get default data view API returns the default data view identifier.
       value:
         data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
     set_default_data_view_request:
@@ -1782,6 +1762,13 @@ components:
         data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
         force: true
   parameters:
+    kbn_xsrf:
+      schema:
+        type: string
+      in: header
+      name: kbn-xsrf
+      description: Cross-site request forgery protection
+      required: true
     view_id:
       in: path
       name: viewId
@@ -1790,13 +1777,6 @@ components:
       schema:
         type: string
         example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-    kbn_xsrf:
-      schema:
-        type: string
-      in: header
-      name: kbn-xsrf
-      description: Cross-site request forgery protection
-      required: true
     field_name:
       in: path
       name: fieldName
@@ -1806,22 +1786,120 @@ components:
         type: string
         example: hour_of_day
   schemas:
-    404_response:
+    allownoindex:
+      type: boolean
+      description: Allows the data view saved object to exist before the data is available.
+    fieldattrs:
+      type: object
+      description: A map of field attributes by field name.
+    fieldformats:
+      type: object
+      description: A map of field formats by field name.
+    namespaces:
+      type: array
+      description: An array of space identifiers for sharing the data view between multiple spaces.
+      items:
+        type: string
+        default: default
+    runtimefieldmap:
+      type: object
+      description: A map of runtime field definitions by field name.
+    sourcefilters:
+      type: array
+      description: The array of field names you want to filter out in Discover.
+    timefieldname:
+      type: string
+      description: The timestamp field name, which you use for time-based data views.
+    title:
+      type: string
+      description: Comma-separated list of data streams, indices, and aliases that you want to search. Supports wildcards (`*`).
+    type:
+      type: string
+      description: When set to `rollup`, identifies the rollup data views.
+    typemeta:
+      type: object
+      description: When you use rollup indices, contains the field list for the rollup data view API endpoints.
+    create_data_view_request_object:
+      title: Create data view request
+      type: object
+      required:
+        - data_view
+      properties:
+        data_view:
+          type: object
+          required:
+            - title
+          description: The data view object.
+          properties:
+            allowNoIndex:
+              $ref: '#/components/schemas/allownoindex'
+            fieldAttrs:
+              $ref: '#/components/schemas/fieldattrs'
+            fieldFormats:
+              $ref: '#/components/schemas/fieldformats'
+            fields:
+              type: object
+            id:
+              type: string
+            name:
+              type: string
+              description: The data view name.
+            namespaces:
+              $ref: '#/components/schemas/namespaces'
+            runtimeFieldMap:
+              $ref: '#/components/schemas/runtimefieldmap'
+            sourceFilters:
+              $ref: '#/components/schemas/sourcefilters'
+            timeFieldName:
+              $ref: '#/components/schemas/timefieldname'
+            title:
+              $ref: '#/components/schemas/title'
+            type:
+              $ref: '#/components/schemas/type'
+            typeMeta:
+              $ref: '#/components/schemas/typemeta'
+            version:
+              type: string
+        override:
+          type: boolean
+          description: Override an existing data view if a data view with the provided title already exists.
+          default: false
+    data_view_response_object:
+      title: Data view response properties
       type: object
       properties:
-        error:
-          type: string
-          example: Not Found
-          enum:
-            - Not Found
-        message:
-          type: string
-          example: Saved object [index-pattern/caaad6d0-920c-11ed-b36a-874bd1548a00] not found
-        statusCode:
-          type: integer
-          example: 404
-          enum:
-            - 404
+        data_view:
+          type: object
+          properties:
+            allowNoIndex:
+              $ref: '#/components/schemas/allownoindex'
+            fieldAttrs:
+              $ref: '#/components/schemas/fieldattrs'
+            fieldFormats:
+              $ref: '#/components/schemas/fieldformats'
+            fields:
+              type: object
+            id:
+              type: string
+              example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+            name:
+              type: string
+              description: The data view name.
+            namespaces:
+              $ref: '#/components/schemas/namespaces'
+            runtimeFieldMap:
+              $ref: '#/components/schemas/runtimefieldmap'
+            sourceFilters:
+              $ref: '#/components/schemas/sourcefilters'
+            timeFieldName:
+              $ref: '#/components/schemas/timefieldname'
+            title:
+              $ref: '#/components/schemas/title'
+            typeMeta:
+              $ref: '#/components/schemas/typemeta'
+            version:
+              type: string
+              example: WzQ2LDJd
     400_response:
       title: Bad request
       type: object
@@ -1838,3 +1916,54 @@ components:
           example: Bad Request
         message:
           type: string
+    404_response:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Not Found
+          enum:
+            - Not Found
+        message:
+          type: string
+          example: Saved object [index-pattern/caaad6d0-920c-11ed-b36a-874bd1548a00] not found
+        statusCode:
+          type: integer
+          example: 404
+          enum:
+            - 404
+    update_data_view_request_object:
+      title: Update data view request
+      type: object
+      required:
+        - data_view
+      properties:
+        data_view:
+          type: object
+          description: |
+            The data view properties you want to update. Only the specified properties are updated in the data view. Unspecified fields stay as they are persisted.
+          properties:
+            allowNoIndex:
+              $ref: '#/components/schemas/allownoindex'
+            fieldFormats:
+              $ref: '#/components/schemas/fieldformats'
+            fields:
+              type: object
+            name:
+              type: string
+            runtimeFieldMap:
+              $ref: '#/components/schemas/runtimefieldmap'
+            sourceFilters:
+              $ref: '#/components/schemas/sourcefilters'
+            timeFieldName:
+              $ref: '#/components/schemas/timefieldname'
+            title:
+              $ref: '#/components/schemas/title'
+            type:
+              $ref: '#/components/schemas/type'
+            typeMeta:
+              $ref: '#/components/schemas/typemeta'
+        refresh_fields:
+          type: boolean
+          description: Reloads the data view fields after the data view is updated.
+          default: false

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -114,6 +114,75 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+    post:
+      summary: Updates a data view.
+      operationId: updateDataView
+      description: |
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/view_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - data_view
+              properties:
+                data_view:
+                  type: object
+                  description: |
+                    The data view fields you want to update. Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.
+                  properties:
+                    allowNoIndex:
+                      type: boolean
+                    fieldFormats:
+                      type: object
+                    fields:
+                      type: object
+                    name:
+                      type: string
+                    runtimeFieldMap:
+                      type: object
+                    sourceFilters:
+                      type: array
+                    timeFieldName:
+                      type: string
+                    title:
+                      type: string
+                    type:
+                      type: string
+                    typeMeta:
+                      type: object
+                refresh_fields:
+                  type: boolean
+                  description: Reloads the data view fields after the data view is updated.
+                  default: false
+            examples:
+              updateDataViewRequest:
+                $ref: '#/components/examples/update_data_view_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data_view:
+                    type: object
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_response'
+      servers:
+        - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
   /api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
@@ -1175,6 +1244,15 @@ components:
           name: Kibana Sample Data eCommerce
           namespaces:
             - default
+    update_data_view_request:
+      summary: Update some properties for a data view.
+      value:
+        data_view:
+          title: kibana_sample_data_ecommerce
+          timeFieldName: order_date
+          allowNoIndex: false
+          name: Kibana Sample Data eCommerce
+        refresh_fields: true
     get_runtime_field_response:
       summary: Retrieve a runtime field named `hour_of_day` from the data view `d3d7af60-4c81-11e8-b3d7-01146121b73d`.
       value:
@@ -1692,6 +1770,13 @@ components:
       schema:
         type: string
         example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+    kbn_xsrf:
+      schema:
+        type: string
+      in: header
+      name: kbn-xsrf
+      description: Cross-site request forgery protection
+      required: true
     field_name:
       in: path
       name: fieldName
@@ -1700,13 +1785,6 @@ components:
       schema:
         type: string
         example: hour_of_day
-    kbn_xsrf:
-      schema:
-        type: string
-      in: header
-      name: kbn-xsrf
-      description: Cross-site request forgery protection
-      required: true
   schemas:
     404_response:
       type: object
@@ -1724,3 +1802,19 @@ components:
           example: 404
           enum:
             - 404
+    400_response:
+      title: Bad request
+      type: object
+      required:
+        - statusCode
+        - error
+        - message
+      properties:
+        statusCode:
+          type: number
+          example: 400
+        error:
+          type: string
+          example: Bad Request
+        message:
+          type: string

--- a/src/plugins/data_views/docs/openapi/components/examples/create_data_view_request.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/create_data_view_request.yaml
@@ -1,0 +1,16 @@
+summary: Create a data view with runtime fields.
+value:
+  {
+    "data_view": {
+      "title": "logstash-*",
+      "name": "My Logstash data view",
+      "runtimeFieldMap": {
+        "runtime_shape_name": {
+          "type": "keyword",
+          "script": {
+            "source": "emit(doc['shape_name'].value)"
+          }
+        }
+      }
+    }
+  }

--- a/src/plugins/data_views/docs/openapi/components/examples/create_data_view_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/create_data_view_response.yaml
@@ -1,0 +1,50 @@
+summary: The create data view API returns a JSON object that contains details about the new data view.
+value:
+  {
+    "data_view": {
+      "id": "b561acfb-0181-455e-84a3-ce8980b2272f",
+      "version": "WzQ5LDJd",
+      "title": "logstash-*",
+      "sourceFilters": [],
+      "fields": {
+        "runtime_shape_name": {
+          "count": 0,
+          "name": "runtime_shape_name",
+          "type": "string",
+          "esTypes": [
+            "keyword"
+          ],
+          "scripted": false,
+          "searchable": true,
+          "aggregatable": true,
+          "readFromDocValues": false,
+          "format": {
+            "id": "string"
+          },
+          "shortDotsEnable": false,
+          "runtimeField": {
+            "type": "keyword",
+            "script": {
+              "source": "emit(doc['shape_name'].value)"
+            }
+          }
+        }
+      },
+      "typeMeta": {},
+      "fieldFormats": {},
+      "runtimeFieldMap": {
+        "runtime_shape_name": {
+          "type": "keyword",
+          "script": {
+            "source": "emit(doc['shape_name'].value)"
+          }
+        }
+      },
+      "fieldAttrs": {},
+      "allowNoIndex": false,
+      "name": "My Logstash data view",
+      "namespaces": [
+        "default"
+      ]
+    }
+  }

--- a/src/plugins/data_views/docs/openapi/components/examples/get_data_view_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/get_data_view_response.yaml
@@ -1,4 +1,4 @@
-summary: Retrieve information about a specific data view.
+summary: The get data view API returns a JSON object that contains information about the data view.
 value:
   {
     "data_view": {

--- a/src/plugins/data_views/docs/openapi/components/examples/get_data_views_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/get_data_views_response.yaml
@@ -1,4 +1,4 @@
-summary: Retrieve the list of data views for Kibana sample data.
+summary: The get all data views API returns a list of data views.
 value:
   {
     "data_view": [

--- a/src/plugins/data_views/docs/openapi/components/examples/get_default_data_view_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/get_default_data_view_response.yaml
@@ -1,4 +1,4 @@
-summary: Retrieve the default data view identifier.
+summary: The get default data view API returns the default data view identifier.
 value:
   {
     "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"

--- a/src/plugins/data_views/docs/openapi/components/examples/get_runtime_field_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/get_runtime_field_response.yaml
@@ -1,4 +1,4 @@
-summary: Retrieve a runtime field named `hour_of_day` from the data view `d3d7af60-4c81-11e8-b3d7-01146121b73d`.
+summary: The get runtime field API returns a JSON object that contains information about the runtime field (`hour_of_day`) and the data view (`d3d7af60-4c81-11e8-b3d7-01146121b73d`).
 value:
   {
     "fields": [

--- a/src/plugins/data_views/docs/openapi/components/examples/update_data_view_request.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/update_data_view_request.yaml
@@ -1,0 +1,11 @@
+summary: Update some properties for a data view.
+value:
+  {
+    "data_view": {
+      "title": "kibana_sample_data_ecommerce",
+      "timeFieldName": "order_date",
+      "allowNoIndex": false,
+      "name": "Kibana Sample Data eCommerce"
+    },
+    "refresh_fields": true
+}

--- a/src/plugins/data_views/docs/openapi/components/schemas/400_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/400_response.yaml
@@ -1,0 +1,15 @@
+title: Bad request
+type: object
+required:
+  - statusCode
+  - error
+  - message
+properties:
+  statusCode:
+    type: number
+    example: 400
+  error:
+    type: string
+    example: Bad Request
+  message:
+    type: string

--- a/src/plugins/data_views/docs/openapi/components/schemas/allownoindex.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/allownoindex.yaml
@@ -1,0 +1,2 @@
+type: boolean
+description: Allows the data view saved object to exist before the data is available.

--- a/src/plugins/data_views/docs/openapi/components/schemas/create_data_view_request_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/create_data_view_request_object.yaml
@@ -1,0 +1,44 @@
+title: Create data view request
+type: object
+required:
+  - data_view
+properties:
+  data_view:
+    type: object
+    required:
+      - title
+    description: The data view object.
+    properties:
+      allowNoIndex:
+        $ref: 'allownoindex.yaml'
+      fieldAttrs:
+        $ref: 'fieldattrs.yaml'
+      fieldFormats:
+        $ref: 'fieldformats.yaml'
+      fields:
+        type: object
+      id:
+        type: string
+      name:
+        type: string
+        description: The data view name.
+      namespaces:
+        $ref: 'namespaces.yaml'
+      runtimeFieldMap:
+        $ref: 'runtimefieldmap.yaml'
+      sourceFilters:
+        $ref: 'sourcefilters.yaml'
+      timeFieldName:
+        $ref: 'timefieldname.yaml'
+      title:
+        $ref: 'title.yaml'
+      type:
+        $ref: 'type.yaml'
+      typeMeta:
+        $ref: 'typemeta.yaml'
+      version:
+        type: string
+  override:
+    type: boolean
+    description: Override an existing data view if a data view with the provided title already exists.
+    default: false

--- a/src/plugins/data_views/docs/openapi/components/schemas/data_view_response_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/data_view_response_object.yaml
@@ -1,0 +1,36 @@
+title: Data view response properties
+type: object
+properties:
+  data_view:
+    type: object
+    properties:
+      allowNoIndex:
+        $ref: 'allownoindex.yaml'
+      fieldAttrs:
+        $ref: 'fieldattrs.yaml'
+      fieldFormats:
+        $ref: 'fieldformats.yaml'
+      fields:
+        type: object
+      id:
+        type: string
+        example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+      name:
+        type: string
+        description: The data view name.
+      namespaces:
+        $ref: 'namespaces.yaml'
+      runtimeFieldMap:
+        $ref: 'runtimefieldmap.yaml'
+      sourceFilters:
+        $ref: 'sourcefilters.yaml'
+      timeFieldName:
+        $ref: 'timefieldname.yaml'
+      title:
+        $ref: 'title.yaml'
+      typeMeta:
+        $ref: 'typemeta.yaml'
+      version:
+        type: string
+        example: WzQ2LDJd
+        

--- a/src/plugins/data_views/docs/openapi/components/schemas/fieldattrs.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/fieldattrs.yaml
@@ -1,0 +1,2 @@
+type: object
+description: A map of field attributes by field name.

--- a/src/plugins/data_views/docs/openapi/components/schemas/fieldformats.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/fieldformats.yaml
@@ -1,0 +1,2 @@
+type: object
+description: A map of field formats by field name.

--- a/src/plugins/data_views/docs/openapi/components/schemas/namespaces.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/namespaces.yaml
@@ -1,0 +1,5 @@
+type: array
+description: An array of space identifiers for sharing the data view between multiple spaces.
+items:
+  type: string
+  default: default

--- a/src/plugins/data_views/docs/openapi/components/schemas/runtimefieldmap.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/runtimefieldmap.yaml
@@ -1,0 +1,2 @@
+type: object
+description: A map of runtime field definitions by field name.

--- a/src/plugins/data_views/docs/openapi/components/schemas/sourcefilters.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/sourcefilters.yaml
@@ -1,0 +1,2 @@
+type: array
+description: The array of field names you want to filter out in Discover.

--- a/src/plugins/data_views/docs/openapi/components/schemas/timefieldname.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/timefieldname.yaml
@@ -1,0 +1,2 @@
+type: string
+description: The timestamp field name, which you use for time-based data views.

--- a/src/plugins/data_views/docs/openapi/components/schemas/title.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/title.yaml
@@ -1,0 +1,2 @@
+type: string
+description: Comma-separated list of data streams, indices, and aliases that you want to search. Supports wildcards (`*`).

--- a/src/plugins/data_views/docs/openapi/components/schemas/type.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/type.yaml
@@ -1,0 +1,2 @@
+type: string
+description: When set to `rollup`, identifies the rollup data views.

--- a/src/plugins/data_views/docs/openapi/components/schemas/typemeta.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/typemeta.yaml
@@ -1,0 +1,2 @@
+type: object
+description: When you use rollup indices, contains the field list for the rollup data view API endpoints.

--- a/src/plugins/data_views/docs/openapi/components/schemas/update_data_view_request_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/update_data_view_request_object.yaml
@@ -1,0 +1,35 @@
+title: Update data view request
+type: object
+required:
+  - data_view
+properties:
+  data_view:
+    type: object
+    description: >
+      The data view properties you want to update.
+      Only the specified properties are updated in the data view. Unspecified fields stay as they are persisted.
+    properties:
+      allowNoIndex:
+        $ref: 'allownoindex.yaml'
+      fieldFormats:
+        $ref: 'fieldformats.yaml'
+      fields:
+        type: object
+      name:
+        type: string
+      runtimeFieldMap:
+        $ref: 'runtimefieldmap.yaml'
+      sourceFilters:
+        $ref: 'sourcefilters.yaml'
+      timeFieldName:
+        $ref: 'timefieldname.yaml'
+      title:
+        $ref: 'title.yaml'
+      type:
+        $ref: 'type.yaml'
+      typeMeta:
+        $ref: 'typemeta.yaml'
+  refresh_fields:
+    type: boolean
+    description: Reloads the data view fields after the data view is updated.
+    default: false

--- a/src/plugins/data_views/docs/openapi/entrypoint.yaml
+++ b/src/plugins/data_views/docs/openapi/entrypoint.yaml
@@ -18,8 +18,8 @@ paths:
 # Default space
   '/api/data_views':
     $ref: 'paths/api@data_views.yaml'
-#  '/api/data_views/data_view':
-#    $ref: 'paths/api@data_views@data_view.yaml'
+  '/api/data_views/data_view':
+    $ref: 'paths/api@data_views@data_view.yaml'
   '/api/data_views/data_view/{viewId}':
     $ref: 'paths/api@data_views@data_view@{viewid}.yaml'
 #  '/api/data_views/data_view/{viewId}/fields':

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
@@ -1,0 +1,36 @@
+post:
+  summary: Creates a data view.
+  operationId: createDataView
+  description: >
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/create_data_view_request_object.yaml'
+        examples:
+          createDataViewRequest:
+            $ref: '../components/examples/create_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/data_view_response_object.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/400_response.yaml'
+  servers:
+    - url: https://localhost:5601
+
+servers:
+  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
@@ -56,6 +56,28 @@ get:
           schema:
             $ref: '../components/schemas/404_response.yaml'
 
+delete:
+  summary: Deletes a data view.
+  operationId: deleteDataView
+  description: >
+    WARNING: When you delete a data view, it cannot be recovered.
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/parameters/view_id.yaml'
+  responses:
+    '204':
+      description: Indicates a successful call.
+    '404':
+      description: Object is not found.
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/404_response.yaml'
+  servers:
+    - url: https://localhost:5601
+
 post:
   summary: Updates a data view.
   operationId: updateDataView

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
@@ -13,39 +13,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              data_view:
-                type: object
-                properties:
-                  allowNoIndex:
-                    type: boolean
-                  fieldAttrs:
-                    type: object
-                  fieldFormats:
-                    type: object
-                  fields:
-                    type: object
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  namespaces:
-                    type: array
-                    items:
-                      type: string
-                  runtimeFieldMap:
-                    type: object
-                  sourceFilters:
-                    type: array
-                  timeFieldName:
-                    type: string
-                  title:
-                    type: string
-                  typeMeta:
-                    type: object
-                  version:
-                    type: string
+            $ref: '../components/schemas/data_view_response_object.yaml'
           examples:
             getDataViewResponse:
               $ref: '../components/examples/get_data_view_response.yaml'
@@ -93,40 +61,7 @@ post:
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - data_view
-          properties:
-            data_view:
-              type: object
-              description: >
-                The data view fields you want to update.
-                Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.
-              properties:
-                allowNoIndex:
-                  type: boolean
-                fieldFormats:
-                  type: object
-                fields:
-                  type: object
-                name:
-                  type: string
-                runtimeFieldMap:
-                  type: object
-                sourceFilters:
-                  type: array
-                timeFieldName:
-                  type: string
-                title:
-                  type: string
-                type:
-                  type: string
-                typeMeta:
-                  type: object
-            refresh_fields:
-              type: boolean
-              description: Reloads the data view fields after the data view is updated.
-              default: false
+          $ref: '../components/schemas/update_data_view_request_object.yaml'
         examples:
           updateDataViewRequest:
             $ref: '../components/examples/update_data_view_request.yaml'
@@ -136,10 +71,7 @@ post:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              data_view:
-                type: object
+            $ref: '../components/schemas/data_view_response_object.yaml'
     '400':
       description: Bad request
       content:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
@@ -55,5 +55,77 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
+
+post:
+  summary: Updates a data view.
+  operationId: updateDataView
+  description: >
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+    - $ref: '../components/parameters/view_id.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - data_view
+          properties:
+            data_view:
+              type: object
+              description: >
+                The data view fields you want to update.
+                Only the specified fields are updated in the data view. Unspecified fields stay as they are persisted.
+              properties:
+                allowNoIndex:
+                  type: boolean
+                fieldFormats:
+                  type: object
+                fields:
+                  type: object
+                name:
+                  type: string
+                runtimeFieldMap:
+                  type: object
+                sourceFilters:
+                  type: array
+                timeFieldName:
+                  type: string
+                title:
+                  type: string
+                type:
+                  type: string
+                typeMeta:
+                  type: object
+            refresh_fields:
+              type: boolean
+              description: Reloads the data view fields after the data view is updated.
+              default: false
+        examples:
+          updateDataViewRequest:
+            $ref: '../components/examples/update_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data_view:
+                type: object
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/400_response.yaml'
+  servers:
+    - url: https://localhost:5601
+
 servers:
   - url: https://localhost:5601


### PR DESCRIPTION
This PR builds on the changes in https://github.com/elastic/kibana/pull/163444

It updates the open API specification to include [delete data view](https://www.elastic.co/guide/en/kibana/master/data-views-api-delete.html) and [update data view](https://www.elastic.co/guide/en/kibana/master/data-views-api-update.html), and [create data view](https://www.elastic.co/guide/en/kibana/master/data-views-api-create.html).